### PR TITLE
chore(ci): update claude-code-action from beta to v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Updated `claude-code-action` from `@beta` to `@v1` in both workflow files
- `v1` is the latest stable release (released Aug 26, 2025)

## Changes
- `.github/workflows/claude.yml`: Update action version to v1
- `.github/workflows/claude-code-review.yml`: Update action version to v1

## Test plan
- [ ] Verify workflows still trigger correctly on issue comments and PR events
- [ ] Confirm Claude Code functionality works as expected with v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)