### PR TITLE
fix(daemon): base64 encode encrypted track data for JSON transport

### DIFF
--- a/daemon/handlers.sync.go
+++ b/daemon/handlers.sync.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"log/slog"
 	"time"
@@ -79,9 +80,9 @@ func handlePubSubSync(ctx context.Context, socketMsgPayload interface{}) error {
 			}
 
 			realPayload = model.PostTrackArgs{
-				Encrypted: string(encryptedData),
-				AesKey:    string(encodedKey),
-				Nonce:     string(nonce),
+				Encrypted: base64.StdEncoding.EncodeToString(encryptedData),
+				AesKey:    base64.StdEncoding.EncodeToString(encodedKey),
+				Nonce:     base64.StdEncoding.EncodeToString(nonce),
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix encrypted mode failing when using JSON transport in the track API
- Add base64 encoding for `Encrypted`, `AesKey`, and `Nonce` fields before sending to server

## Root Cause
Raw binary ciphertext was being stored as strings and JSON-serialized, causing data corruption due to invalid UTF-8 sequences being replaced with `\ufffd`.

## Changes
- `daemon/handlers.sync.go`: Base64 encode `encryptedData`, `encodedKey`, and `nonce` before storing in `PostTrackArgs`

## Related PR
- Server PR: shelltime/server (deploy together)

## Test plan
- [ ] Deploy server and CLI together (both need to be updated)
- [ ] Test encrypted mode with JSON content-type
- [ ] Test encrypted mode with msgpack content-type
- [ ] Verify unencrypted mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)