### PR TITLE
feat(otel): add complete OTEL configuration fields

### DIFF
--- a/model/ccotel_env.go
+++ b/model/ccotel_env.go
@@ -115,6 +115,13 @@ func NewBashCCOtelEnvService() CCOtelEnvService {
 		"export OTEL_LOGS_EXPORTER=otlp",
 		"export OTEL_EXPORTER_OTLP_PROTOCOL=grpc",
 		"export OTEL_EXPORTER_OTLP_ENDPOINT=" + ccOtelEndpoint,
+		"export OTEL_METRIC_EXPORT_INTERVAL=10000",
+		"export OTEL_LOGS_EXPORT_INTERVAL=5000",
+		"export OTEL_LOG_USER_PROMPTS=1",
+		"export OTEL_METRICS_INCLUDE_SESSION_ID=true",
+		"export OTEL_METRICS_INCLUDE_VERSION=true",
+		"export OTEL_METRICS_INCLUDE_ACCOUNT_UUID=true",
+		"export OTEL_RESOURCE_ATTRIBUTES=\"user.name=$(whoami),machine.name=$(hostname),team.id=shelltime\"",
 		ccOtelMarkerEnd,
 	}
 
@@ -200,6 +207,13 @@ func NewZshCCOtelEnvService() CCOtelEnvService {
 		"export OTEL_LOGS_EXPORTER=otlp",
 		"export OTEL_EXPORTER_OTLP_PROTOCOL=grpc",
 		"export OTEL_EXPORTER_OTLP_ENDPOINT=" + ccOtelEndpoint,
+		"export OTEL_METRIC_EXPORT_INTERVAL=10000",
+		"export OTEL_LOGS_EXPORT_INTERVAL=5000",
+		"export OTEL_LOG_USER_PROMPTS=1",
+		"export OTEL_METRICS_INCLUDE_SESSION_ID=true",
+		"export OTEL_METRICS_INCLUDE_VERSION=true",
+		"export OTEL_METRICS_INCLUDE_ACCOUNT_UUID=true",
+		"export OTEL_RESOURCE_ATTRIBUTES=\"user.name=$(whoami),machine.name=$(hostname),team.id=shelltime\"",
 		ccOtelMarkerEnd,
 	}
 
@@ -282,6 +296,13 @@ func NewFishCCOtelEnvService() CCOtelEnvService {
 		"set -gx OTEL_LOGS_EXPORTER otlp",
 		"set -gx OTEL_EXPORTER_OTLP_PROTOCOL grpc",
 		"set -gx OTEL_EXPORTER_OTLP_ENDPOINT " + ccOtelEndpoint,
+		"set -gx OTEL_METRIC_EXPORT_INTERVAL 10000",
+		"set -gx OTEL_LOGS_EXPORT_INTERVAL 5000",
+		"set -gx OTEL_LOG_USER_PROMPTS 1",
+		"set -gx OTEL_METRICS_INCLUDE_SESSION_ID true",
+		"set -gx OTEL_METRICS_INCLUDE_VERSION true",
+		"set -gx OTEL_METRICS_INCLUDE_ACCOUNT_UUID true",
+		"set -gx OTEL_RESOURCE_ATTRIBUTES \"user.name=$(whoami),machine.name=$(hostname),team.id=shelltime\"",
 		ccOtelMarkerEnd,
 	}
 


### PR DESCRIPTION
Added missing OpenTelemetry configuration fields for all supported shells (bash, zsh, fish):

- OTEL_METRIC_EXPORT_INTERVAL (10000ms)
- OTEL_LOGS_EXPORT_INTERVAL (5000ms)
- OTEL_LOG_USER_PROMPTS (enabled)
- OTEL_METRICS_INCLUDE_SESSION_ID (enabled)
- OTEL_METRICS_INCLUDE_VERSION (enabled)
- OTEL_METRICS_INCLUDE_ACCOUNT_UUID (enabled)
- OTEL_RESOURCE_ATTRIBUTES (with dynamic user.name, machine.name, team.id)

This provides comprehensive telemetry configuration as requested in issue #142.

Fixes #142

Generated with [Claude Code](https://claude.ai/code)