### PR TITLE
fix(model): use template variable for binary path in Linux service file

### DIFF
--- a/model/sys-desc/shelltime.service
+++ b/model/sys-desc/shelltime.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/bin/sh -c 'exec $(getent passwd $USER | cut -d: -f7) -l -c "/usr/local/bin/shelltime-daemon"'
+ExecStart=/bin/sh -c 'exec $(getent passwd $USER | cut -d: -f7) -l -c "{{.BaseFolder}}/bin/shelltime-daemon"'
 Restart=always
 
 # Resource limits


### PR DESCRIPTION
Updated shelltime.service to use {{.BaseFolder}}/bin/shelltime-daemon instead of hardcoded /usr/local/bin/shelltime-daemon to match the pattern used in macOS configuration.

Fixes #152

Generated with [Claude Code](https://claude.ai/code)