### PR TITLE
feat(ccotel): add debug config for raw JSON output

### DIFF
--- a/model/types.go
+++ b/model/types.go
@@ -29,6 +29,7 @@ type CCUsage struct {
 type CCOtel struct {
 	Enabled  *bool `toml:"enabled"`
 	GRPCPort int   `toml:"grpcPort"` // default: 4317
+	Debug    *bool `toml:"debug"`    // write raw JSON to debug files
 }
 
 // CodeTracking configuration for coding activity heartbeat tracking


### PR DESCRIPTION
## Summary
- Add `debug` option to CCOtel config for troubleshooting OTEL data
- When enabled, writes raw JSON metrics/logs to `/tmp/shelltime/ccotel-debug-{metrics,logs}.txt`
- Includes timestamps for each entry

## Config Example
```toml
[ccotel]
enabled = true
grpcPort = 54027
debug = true
```

## Test plan
- [ ] Enable debug in config and verify files are created in `/tmp/shelltime/`
- [ ] Verify metrics and logs are written in readable JSON format
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)