### PR TITLE
refactor(cli): rename init command to auth and add new init orchestrator

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -93,6 +93,7 @@ func main() {
 	}
 
 	app.Commands = []*cli.Command{
+		commands.InitCommand,
 		commands.AuthCommand,
 		commands.TrackCommand,
 		commands.GCCommand,

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -17,8 +17,8 @@ import (
 )
 
 var AuthCommand *cli.Command = &cli.Command{
-	Name:  "init",
-	Usage: "init your shelltime.xyz config",
+	Name:  "auth",
+	Usage: "Authenticate with shelltime.xyz",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:     "token",

--- a/commands/init.go
+++ b/commands/init.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"github.com/gookit/color"
+	"github.com/urfave/cli/v2"
+)
+
+var InitCommand *cli.Command = &cli.Command{
+	Name:  "init",
+	Usage: "Initialize shelltime: authenticate, install hooks, and start daemon",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "token",
+			Aliases:  []string{"t"},
+			Usage:    "Authentication token",
+			Required: false,
+		},
+	},
+	Action: commandInit,
+}
+
+func commandInit(c *cli.Context) error {
+	color.Yellow.Println("Initializing ShellTime...")
+
+	// Step 1: Authenticate
+	if err := commandAuth(c); err != nil {
+		return err
+	}
+
+	// Step 2: Install shell hooks
+	if err := commandHooksInstall(c); err != nil {
+		return err
+	}
+
+	// Step 3: Install daemon service
+	if err := commandDaemonInstall(c); err != nil {
+		return err
+	}
+
+	color.Green.Println("ShellTime is fully initialized and ready to use!")
+	return nil
+}


### PR DESCRIPTION
## Summary
- Rename existing `init` command to `auth` for clearer naming
- Add new `init` command that orchestrates full setup:
  1. Authenticates with shelltime.xyz
  2. Installs shell hooks (bash, zsh, fish)
  3. Installs daemon service

## Test plan
- [ ] Run `shelltime auth --help` to verify auth command works
- [ ] Run `shelltime init --help` to verify init command works
- [ ] Run `shelltime init` to test full initialization flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)