### PR TITLE
feat(daemon): display CCOtel debug config in status command

### DIFF
--- a/commands/daemon.status.go
+++ b/commands/daemon.status.go
@@ -64,7 +64,11 @@ func commandDaemonStatus(c *cli.Context) error {
 	fmt.Printf("  Socket Path: %s\n", socketPath)
 
 	if cfg.CCOtel != nil && cfg.CCOtel.Enabled != nil && *cfg.CCOtel.Enabled {
-		fmt.Printf("  CCOtel: enabled (port %d)\n", cfg.CCOtel.GRPCPort)
+		debugStatus := "off"
+		if cfg.CCOtel.Debug != nil && *cfg.CCOtel.Debug {
+			debugStatus = "on"
+		}
+		fmt.Printf("  CCOtel: enabled (port %d, debug %s)\n", cfg.CCOtel.GRPCPort, debugStatus)
 	} else {
 		fmt.Println("  CCOtel: disabled")
 	}


### PR DESCRIPTION
## Summary
- Add debug flag status display to `daemon status` command output
- When CCOtel is enabled, now shows: `CCOtel: enabled (port 4317, debug on/off)`

## Test plan
- [ ] Run `shelltime daemon status` with CCOtel enabled and debug on
- [ ] Run `shelltime daemon status` with CCOtel enabled and debug off
- [ ] Run `shelltime daemon status` with CCOtel disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)