### PR TITLE
Fix shelltime service not running on Linux

### DIFF
--- a/model/daemon-installer.linux.go
+++ b/model/daemon-installer.linux.go
@@ -166,7 +166,8 @@ func (l *LinuxDaemonInstaller) GetDaemonServiceFile(username string) (buf bytes.
 		return
 	}
 	err = tmpl.Execute(&buf, map[string]string{
-		"UserName": username,
+		"UserName":   username,
+		"BaseFolder": l.baseFolder,
 	})
 	return
 }

--- a/model/sys-desc/shelltime.service
+++ b/model/sys-desc/shelltime.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/bin/sh -c 'exec $(getent passwd $USER | cut -d: -f7) -l -c "{{.BaseFolder}}/bin/shelltime-daemon"'
+ExecStart=/bin/sh -c 'exec $(getent passwd $(id -un) | cut -d: -f7) -l -c "{{.BaseFolder}}/bin/shelltime-daemon"'
 Restart=always
 
 # Resource limits


### PR DESCRIPTION
The Linux systemd service was failing to start due to two issues:

1. BaseFolder was missing from template data in GetDaemonServiceFile, causing {{.BaseFolder}} to render as empty, resulting in invalid daemon path "/bin/shelltime-daemon" instead of the correct path.

2. $USER environment variable is not available in systemd user services, causing getent passwd $USER to fail. Replaced with $(id -un) which reliably returns the current username without depending on environment.

This aligns the Linux implementation with the working macOS version.