### PR TITLE
fix(config): make endpoints optional and use relative schema path

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -45,7 +45,7 @@ func commandAuth(c *cli.Context) error {
 	SetupLogger(configDir)
 
 	// Generate JSON schema for IDE autocompletion
-	schemaFile := configDir + "/config.schema.json"
+	schemaFile := configDir + "/config-schema.json"
 	if err := generateSchemaFile(schemaFile); err != nil {
 		slog.Warn("Failed to generate schema file", slog.Any("err", err))
 	}
@@ -58,7 +58,7 @@ func commandAuth(c *cli.Context) error {
 			return fmt.Errorf("failed to marshal default config: %w", err)
 		}
 		// Prepend $schema for IDE autocompletion support
-		schemaHeader := "# yaml-language-server: $schema=" + schemaFile + "\n"
+		schemaHeader := "# yaml-language-server: $schema=./config-schema.json\n"
 		content = append([]byte(schemaHeader), content...)
 		err = os.WriteFile(configFile, content, 0644)
 		if err != nil {

--- a/model/types.go
+++ b/model/types.go
@@ -60,7 +60,7 @@ type ShellTimeConfig struct {
 	DataMasking *bool `toml:"dataMasking" yaml:"dataMasking" json:"dataMasking"`
 
 	// for debug purpose
-	Endpoints []Endpoint `toml:"ENDPOINTS" yaml:"endpoints" json:"endpoints"`
+	Endpoints []Endpoint `toml:"ENDPOINTS,omitempty" yaml:"endpoints,omitempty" json:"endpoints,omitempty"`
 
 	// WARNING
 	// This config will track each command metrics you run in current shell.


### PR DESCRIPTION
## Summary
- Add `omitempty` tag to `Endpoints` field in config struct for proper optional serialization
- Change YAML schema reference from absolute path to relative `./config-schema.json`

## Test plan
- [ ] Verify config serialization omits empty endpoints field
- [ ] Verify new config files reference schema with relative path

🤖 Generated with [Claude Code](https://claude.com/claude-code)