### PR TITLE
fix(daemon): add acknowledgment response for heartbeat messages

### DIFF
--- a/daemon/socket.go
+++ b/daemon/socket.go
@@ -128,6 +128,8 @@ func (p *SocketHandler) handleConnection(conn net.Conn) {
 		// Only process heartbeat if codeTracking is enabled
 		if p.config.CodeTracking == nil || p.config.CodeTracking.Enabled == nil || !*p.config.CodeTracking.Enabled {
 			slog.Debug("Heartbeat message received but codeTracking is disabled, ignoring")
+			encoder := json.NewEncoder(conn)
+			encoder.Encode(map[string]string{"status": "disabled"})
 			return
 		}
 		buf, err := json.Marshal(msg)
@@ -140,6 +142,10 @@ func (p *SocketHandler) handleConnection(conn net.Conn) {
 		if err := p.channel.Publish(PubSubTopic, chMsg); err != nil {
 			slog.Error("Error publishing heartbeat topic", slog.Any("err", err))
 		}
+
+		// Send acknowledgment to client
+		encoder := json.NewEncoder(conn)
+		encoder.Encode(map[string]string{"status": "ok"})
 	default:
 		slog.Error("Unknown message type:", slog.String("messageType", string(msg.Type)))
 	}


### PR DESCRIPTION
## Summary
- Send `{"status":"ok"}` after processing heartbeat message
- Send `{"status":"disabled"}` when codeTracking is disabled

## Problem
The VS Code extension showed "daemon not running" warning even when the daemon was running. The root cause was that the daemon didn't send any response for heartbeat messages, causing the extension to interpret the empty response as a connection failure.

## Solution
Add acknowledgment responses for heartbeat messages:
- `{"status":"ok"}` - heartbeat was received and published to PubSub
- `{"status":"disabled"}` - codeTracking is disabled, heartbeat was ignored

## Test plan
- [ ] Enable codeTracking, send heartbeat - should receive `{"status":"ok"}`
- [ ] Disable codeTracking, send heartbeat - should receive `{"status":"disabled"}`
- [ ] VS Code extension should show "Connected" status after heartbeat

🤖 Generated with [Claude Code](https://claude.com/claude-code)