### PR TITLE
fix(model): add backward compatibility for deprecated ccotel config key

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -154,6 +154,10 @@ func mergeConfig(base, local *ShellTimeConfig) {
 	if local.CCUsage != nil {
 		base.CCUsage = local.CCUsage
 	}
+	// Migrate deprecated ccotel from local config
+	if local.CCOtel != nil && local.AICodeOtel == nil {
+		local.AICodeOtel = local.CCOtel
+	}
 	if local.AICodeOtel != nil {
 		base.AICodeOtel = local.AICodeOtel
 	}
@@ -211,6 +215,12 @@ func (cs *configService) ReadConfigFile(ctx context.Context, opts ...ReadConfigO
 	if err != nil {
 		err = fmt.Errorf("failed to parse config file: %w", err)
 		return
+	}
+
+	// Migrate deprecated ccotel field to AICodeOtel (silent migration)
+	if config.CCOtel != nil && config.AICodeOtel == nil {
+		config.AICodeOtel = config.CCOtel
+		config.CCOtel = nil
 	}
 
 	// Read and merge local config if exists

--- a/model/types.go
+++ b/model/types.go
@@ -81,6 +81,10 @@ type ShellTimeConfig struct {
 	// CCUsage configuration for Claude Code usage tracking (v1 - ccusage CLI based)
 	CCUsage *CCUsage `toml:"ccusage" yaml:"ccusage" json:"ccusage"`
 
+	// CCOtel is deprecated, use AICodeOtel instead
+	// Deprecated: This field will be removed in a future version
+	CCOtel *AICodeOtel `toml:"ccotel" yaml:"ccotel" json:"ccotel"`
+
 	// AICodeOtel configuration for OTEL-based AI CLI tracking (Claude Code, Codex, etc.)
 	AICodeOtel *AICodeOtel `toml:"aiCodeOtel" yaml:"aiCodeOtel" json:"aiCodeOtel"`
 
@@ -118,6 +122,7 @@ var DefaultConfig = ShellTimeConfig{
 	AI:            DefaultAIConfig,
 	Exclude:       []string{},
 	CCUsage:       nil,
+	CCOtel:        nil, // deprecated
 	AICodeOtel:    nil,
 	CodeTracking:  nil,
 	LogCleanup:    nil,


### PR DESCRIPTION
## Summary

- Add backward compatibility for the `ccotel` → `aiCodeOtel` config key rename from #181
- Users with existing configs using `ccotel` will continue to work seamlessly
- Silent migration at config read time (no deprecation warnings)

## Changes

- Add deprecated `CCOtel` field to `ShellTimeConfig` with old `ccotel` tags
- Migrate `ccotel` to `AICodeOtel` in `ReadConfigFile` after unmarshal
- Handle deprecated field in `mergeConfig` for local config overrides

## Behavior

| Config State | Result |
|--------------|--------|
| Only `ccotel` set | Migrated to `AICodeOtel`, works ✓ |
| Only `aiCodeOtel` set | Works as-is ✓ |
| Both set | `aiCodeOtel` takes precedence ✓ |

## Test plan

- [x] Existing config tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)