### PR TITLE
refactor(model): remove config discovery log statement

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -200,15 +200,6 @@ func (cs *configService) ReadConfigFile(ctx context.Context, opts ...ReadConfigO
 	// Discover config files with priority
 	files := findConfigFiles(cs.configDir)
 
-	slog.InfoContext(
-		ctx,
-		"config.ReadConfigFile discovered config files",
-		slog.String("base", files.baseFile),
-		slog.String("local", files.localFile),
-		slog.String("base_format", string(files.baseFormat)),
-		slog.String("local_format", string(files.localFormat)),
-	)
-
 	// Read base config file
 	if files.baseFile == "" {
 		err = fmt.Errorf("no config file found in %s", cs.configDir)


### PR DESCRIPTION
Remove the slog.InfoContext call that logged discovered config files in ReadConfigFile function to reduce verbosity.

Fixes #184

---
Generated with [Claude Code](https://claude.ai/code)