### PR TITLE
fix(daemon): convert cc_info timestamps to UTC before sending to server

### DIFF
--- a/daemon/cc_info_timer.go
+++ b/daemon/cc_info_timer.go
@@ -217,10 +217,14 @@ func (s *CCInfoTimerService) fetchCost(ctx context.Context, timeRange CCInfoTime
 		since = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	}
 
+	// Convert to UTC before sending to server to avoid timezone parsing issues
+	sinceUTC := since.UTC()
+	nowUTC := now.UTC()
+
 	variables := map[string]interface{}{
 		"filter": map[string]interface{}{
-			"since":      since.Format(time.RFC3339),
-			"until":      now.Format(time.RFC3339),
+			"since":      sinceUTC.Format(time.RFC3339),
+			"until":      nowUTC.Format(time.RFC3339),
 			"clientType": "claude_code",
 		},
 	}

--- a/model/cc_statusline_service.go
+++ b/model/cc_statusline_service.go
@@ -55,10 +55,14 @@ func FetchDailyCost(ctx context.Context, config ShellTimeConfig) (float64, error
 	now := time.Now()
 	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
+	// Convert to UTC before sending to server to avoid timezone parsing issues
+	startOfDayUTC := startOfDay.UTC()
+	nowUTC := now.UTC()
+
 	variables := map[string]interface{}{
 		"filter": map[string]interface{}{
-			"since":      startOfDay.Format(time.RFC3339),
-			"until":      now.Format(time.RFC3339),
+			"since":      startOfDayUTC.Format(time.RFC3339),
+			"until":      nowUTC.Format(time.RFC3339),
 			"clientType": "claude_code",
 		},
 	}


### PR DESCRIPTION
## Summary
- Convert local timezone timestamps to UTC before sending to the server in cc_info fetching
- Fixes timezone mismatch when server stores/queries data in UTC but client sends local timezone offsets
- Affects both `daemon/cc_info_timer.go` and `model/cc_statusline_service.go`

## Test plan
- [x] All existing tests pass (`go test ./daemon/... ./model/...`)
- [ ] Manual verification: Run daemon in non-UTC timezone and verify correct cost data is returned for "today"

🤖 Generated with [Claude Code](https://claude.com/claude-code)