### PR TITLE
feat(statusline): add total AI agent time to CC statusline display

### DIFF
--- a/daemon/socket.go
+++ b/daemon/socket.go
@@ -36,9 +36,10 @@ type CCInfoRequest struct {
 }
 
 type CCInfoResponse struct {
-	TotalCostUSD float64   `json:"totalCostUsd"`
-	TimeRange    string    `json:"timeRange"`
-	CachedAt     time.Time `json:"cachedAt"`
+	TotalCostUSD        float64   `json:"totalCostUsd"`
+	TotalSessionSeconds int       `json:"totalSessionSeconds"`
+	TimeRange           string    `json:"timeRange"`
+	CachedAt            time.Time `json:"cachedAt"`
 }
 
 // StatusResponse contains daemon status information
@@ -209,9 +210,10 @@ func (p *SocketHandler) handleCCInfo(conn net.Conn, msg SocketMessage) {
 	p.ccInfoTimer.NotifyActivity()
 
 	response := CCInfoResponse{
-		TotalCostUSD: cache.TotalCostUSD,
-		TimeRange:    string(timeRange),
-		CachedAt:     cache.FetchedAt,
+		TotalCostUSD:        cache.TotalCostUSD,
+		TotalSessionSeconds: cache.TotalSessionSeconds,
+		TimeRange:           string(timeRange),
+		CachedAt:            cache.FetchedAt,
 	}
 
 	encoder := json.NewEncoder(conn)

--- a/model/cc_statusline_types.go
+++ b/model/cc_statusline_types.go
@@ -40,7 +40,8 @@ type CCStatuslineDailyCostResponse struct {
 	FetchUser struct {
 		AICodeOtel struct {
 			Analytics struct {
-				TotalCostUsd float64 `json:"totalCostUsd"`
+				TotalCostUsd        float64 `json:"totalCostUsd"`
+				TotalSessionSeconds int     `json:"totalSessionSeconds"`
 			} `json:"analytics"`
 		} `json:"aiCodeOtel"`
 	} `json:"fetchUser"`
@@ -52,6 +53,7 @@ const CCStatuslineDailyCostQuery = `query fetchAICodeOtelAnalytics($filter: AICo
 		aiCodeOtel {
 			analytics(filter: $filter) {
 				totalCostUsd
+				totalSessionSeconds
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Add `totalSessionSeconds` from backend GraphQL API to the CC statusline display
- New display format: `🤖 model | 💰 $session | 📊 $daily | ⏱️ time | 📈 context%`
- Time formatted smartly: `45s`, `2m5s`, or `1h30m`

## Test plan
- [x] All CC statusline tests pass
- [x] All CC info timer tests pass
- [x] All cache tests pass
- [ ] Manual testing with daemon running

🤖 Generated with [Claude Code](https://claude.com/claude-code)