### PR TITLE
ci(workflows): migrate all runners to self-hosted jp-arm-oracle

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: jp-arm-oracle
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: jp-arm-oracle
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: jp-arm-oracle
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: jp-arm-oracle
     environment: CI
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## Summary
- Migrate all GitHub Actions workflow runners from `ubuntu-latest` to self-hosted `jp-arm-oracle`
- Affects: claude-code-review.yml, claude.yml, pr-check.yaml, release.yaml

## Test plan
- [ ] Verify self-hosted runner `jp-arm-oracle` is online and registered
- [ ] Trigger a PR check to validate the runner works correctly
- [ ] Confirm Go tests pass on ARM architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)