### PR TITLE
ci(workflows): switch from self-hosted to ubuntu-latest runner

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: jp-arm-oracle
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: jp-arm-oracle
+    runs-on: ubuntu-latest
     environment: CI
     steps:
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## Summary
- Switch CI runner from `jp-arm-oracle` (self-hosted) to `ubuntu-latest` for PR check and release workflows
- Claude Code related workflows (`claude-code-review.yml`, `claude.yml`) are kept unchanged

## Test plan
- [ ] Verify PR check workflow runs successfully on `ubuntu-latest`
- [ ] Verify release workflow runs successfully on `ubuntu-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)