### PR TITLE
fix(stloader): slow down shine animation interval for better UX

### DIFF
--- a/stloader/loader.go
+++ b/stloader/loader.go
@@ -20,7 +20,7 @@ var DefaultSymbols = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "
 // Default configuration values
 const (
 	DefaultSpinInterval  = 200 * time.Millisecond
-	DefaultShineInterval = 32 * time.Millisecond
+	DefaultShineInterval = 80 * time.Millisecond
 )
 
 // LoaderConfig holds configuration options for the loader


### PR DESCRIPTION
## Summary
- Increase `DefaultShineInterval` from 32ms to 80ms in `stloader/loader.go`
- Makes the loading animation (~12 FPS) more comfortable to watch than the previous ~31 FPS

## Test plan
- [ ] Build the CLI: `go build -o shelltime ./cmd/cli/main.go`
- [ ] Run a query: `./shelltime query "test"` and observe the loading animation
- [ ] Verify the shine effect is slower and easier on the eyes

🤖 Generated with [Claude Code](https://claude.com/claude-code)