### PR TITLE
feat(commands): make daily cost clickable in cc statusline

### DIFF
--- a/commands/cc_statusline_test.go
+++ b/commands/cc_statusline_test.go
@@ -150,7 +150,7 @@ func (s *CCStatuslineTestSuite) TestGetDaemonInfo_UsesDefaultSocketPath() {
 // formatStatuslineOutput Tests
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_AllValues() {
-	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "main", false, nil, nil)
+	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "main", false, nil, nil, "", "")
 
 	// Should contain all components
 	assert.Contains(s.T(), output, "🌿 main")
@@ -162,7 +162,7 @@ func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_AllValues() {
 }
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_WithDirtyBranch() {
-	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "feature/test", true, nil, nil)
+	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "feature/test", true, nil, nil, "", "")
 
 	// Should contain branch with asterisk for dirty
 	assert.Contains(s.T(), output, "🌿 feature/test*")
@@ -170,7 +170,7 @@ func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_WithDirtyBranch() {
 }
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_NoBranch() {
-	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "", false, nil, nil)
+	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "", false, nil, nil, "", "")
 
 	// Should show "-" for no branch
 	assert.Contains(s.T(), output, "🌿 -")
@@ -178,7 +178,7 @@ func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_NoBranch() {
 }
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_ZeroDailyCost() {
-	output := formatStatuslineOutput("claude-sonnet", 0.50, 0, 300, 50.0, "main", false, nil, nil)
+	output := formatStatuslineOutput("claude-sonnet", 0.50, 0, 300, 50.0, "main", false, nil, nil, "", "")
 
 	// Should show "-" for zero daily cost
 	assert.Contains(s.T(), output, "📊 -")
@@ -186,14 +186,14 @@ func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_ZeroDailyCost() {
 }
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_ZeroSessionSeconds() {
-	output := formatStatuslineOutput("claude-sonnet", 0.50, 1.0, 0, 50.0, "main", false, nil, nil)
+	output := formatStatuslineOutput("claude-sonnet", 0.50, 1.0, 0, 50.0, "main", false, nil, nil, "", "")
 
 	// Should show "-" for zero session seconds
 	assert.Contains(s.T(), output, "⏱️ -")
 }
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_HighContextPercentage() {
-	output := formatStatuslineOutput("test-model", 1.0, 1.0, 60, 85.0, "main", false, nil, nil)
+	output := formatStatuslineOutput("test-model", 1.0, 1.0, 60, 85.0, "main", false, nil, nil, "", "")
 
 	// Should contain the percentage (color codes may vary)
 	assert.Contains(s.T(), output, "85%")
@@ -201,7 +201,7 @@ func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_HighContextPercentage
 }
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_LowContextPercentage() {
-	output := formatStatuslineOutput("test-model", 1.0, 1.0, 45, 25.0, "main", false, nil, nil)
+	output := formatStatuslineOutput("test-model", 1.0, 1.0, 45, 25.0, "main", false, nil, nil, "", "")
 
 	// Should contain the percentage
 	assert.Contains(s.T(), output, "25%")
@@ -331,7 +331,7 @@ func (s *CCStatuslineTestSuite) TestFormatQuotaPart_ContainsLink() {
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_WithQuota() {
 	fh := 0.45
 	sd := 0.23
-	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "main", false, &fh, &sd)
+	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "main", false, &fh, &sd, "", "")
 
 	assert.Contains(s.T(), output, "5h:45%")
 	assert.Contains(s.T(), output, "7d:23%")
@@ -339,7 +339,7 @@ func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_WithQuota() {
 }
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_WithoutQuota() {
-	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "main", false, nil, nil)
+	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "main", false, nil, nil, "", "")
 
 	assert.Contains(s.T(), output, "🚦 -")
 }

--- a/daemon/socket.go
+++ b/daemon/socket.go
@@ -45,6 +45,7 @@ type CCInfoResponse struct {
 	GitDirty            bool      `json:"gitDirty"`
 	FiveHourUtilization *float64  `json:"fiveHourUtilization,omitempty"`
 	SevenDayUtilization *float64  `json:"sevenDayUtilization,omitempty"`
+	UserLogin           string    `json:"userLogin,omitempty"`
 }
 
 // StatusResponse contains daemon status information
@@ -228,6 +229,7 @@ func (p *SocketHandler) handleCCInfo(conn net.Conn, msg SocketMessage) {
 		CachedAt:            cache.FetchedAt,
 		GitBranch:           gitInfo.Branch,
 		GitDirty:            gitInfo.Dirty,
+		UserLogin:           p.ccInfoTimer.GetCachedUserLogin(),
 	}
 
 	// Populate rate limit fields if available

--- a/model/user_profile_service.go
+++ b/model/user_profile_service.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"context"
+	"time"
+)
+
+// FetchCurrentUserProfileQuery is the GraphQL query for fetching the current user's profile
+const FetchCurrentUserProfileQuery = `query fetchCurrentUserProfile {
+	fetchUser {
+		id
+		login
+	}
+}`
+
+// UserProfileResponse is the GraphQL response structure for user profile
+type UserProfileResponse struct {
+	FetchUser struct {
+		ID    int    `json:"id"`
+		Login string `json:"login"`
+	} `json:"fetchUser"`
+}
+
+// FetchCurrentUserProfile fetches the current user's profile from the GraphQL API
+func FetchCurrentUserProfile(ctx context.Context, config ShellTimeConfig) (UserProfileResponse, error) {
+	ctx, span := modelTracer.Start(ctx, "userProfile.fetch")
+	defer span.End()
+
+	var result GraphQLResponse[UserProfileResponse]
+
+	err := SendGraphQLRequest(GraphQLRequestOptions[GraphQLResponse[UserProfileResponse]]{
+		Context: ctx,
+		Endpoint: Endpoint{
+			Token:       config.Token,
+			APIEndpoint: config.APIEndpoint,
+		},
+		Query:    FetchCurrentUserProfileQuery,
+		Response: &result,
+		Timeout:  5 * time.Second,
+	})
+
+	if err != nil {
+		return UserProfileResponse{}, err
+	}
+
+	return result.Data, nil
+}


### PR DESCRIPTION
## Summary
- Add `model/user_profile_service.go` with GraphQL query to fetch current user's `login`
- Cache user login in daemon timer service (fetched once per daemon lifetime, never re-fetched)
- Pass `UserLogin` through `CCInfoResponse` from daemon to CLI
- Wrap daily cost section in cc statusline with OSC8 clickable link to `{webEndpoint}/users/{login}/coding-agent/claude-code`
- Fallback path (no daemon) keeps daily cost as plain text

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./daemon/... ./model/...` pass
- [x] `go test -run TestCCStatuslineTestSuite ./commands/` pass
- [ ] Manual: run daemon, verify daily cost section has OSC8 link in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
