### PR TITLE
Configure release-please to always bump patch version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "go",
+      "versioning": "always-bump-patch",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
Updated the release-please configuration to enforce patch version bumps for all releases, ensuring consistent versioning behavior across the project.

## Changes
- Added `"versioning": "always-bump-patch"` to the root package configuration in `release-please-config.json`

## Details
This configuration change ensures that every release will increment the patch version (e.g., 1.0.0 → 1.0.1), even when only documentation or non-code changes are included. This provides more predictable and consistent versioning for Go packages and helps maintain a clear release history.

https://claude.ai/code/session_0139XJqzQZP8N7DxEHRy7S9q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
