### PR TITLE
Update copyright year from 2025 to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ For full details, see [Claude Code Statusline Guide](docs/CC_STATUSLINE.md).
 
 ## License
 
-Copyright (c) 2025 ShellTime Team. All rights reserved.
+Copyright (c) 2026 ShellTime Team. All rights reserved.

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -79,7 +79,7 @@ func main() {
 	app.Description = "shelltime.xyz CLI for track DevOps works"
 	app.Usage = "shelltime.xyz CLI for track DevOps works"
 	app.Version = version
-	app.Copyright = "Copyright (c) 2025 shelltime.xyz Team"
+	app.Copyright = "Copyright (c) 2026 shelltime.xyz Team"
 	app.Authors = []*cli.Author{
 		{
 			Name:  "shelltime.xyz Team",


### PR DESCRIPTION
## Summary
Updates the copyright year in project files from 2025 to 2026 to reflect the current year.

## Changes
- Updated copyright year in README.md
- Updated copyright year in CLI application metadata (cmd/cli/main.go)

## Details
This is a routine annual update to keep copyright notices current across the codebase. The changes affect:
- The main README.md license section
- The CLI application's copyright string displayed to users

https://claude.ai/code/session_01G6xbSx8sXhKA5nWmSZ8Zsj
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
