### PR TITLE
feat(daemon): send session-project path mapping to server

### DIFF
--- a/commands/cc_statusline.go
+++ b/commands/cc_statusline.go
@@ -66,6 +66,24 @@ func commandCCStatusline(c *cli.Context) error {
 	var result ccStatuslineResult
 	config, err := configService.ReadConfigFile(ctx)
 	if err == nil {
+		// Send session-project mapping via daemon socket (fire-and-forget, ~1ms)
+		if data.SessionID != "" {
+			projectPath := ""
+			if data.Workspace != nil {
+				projectPath = data.Workspace.CurrentDir
+				if projectPath == "" {
+					projectPath = data.Workspace.ProjectDir
+				}
+			}
+			if projectPath != "" {
+				socketPath := config.SocketPath
+				if socketPath == "" {
+					socketPath = model.DefaultSocketPath
+				}
+				daemon.SendSessionProject(socketPath, data.SessionID, projectPath)
+			}
+		}
+
 		result = getDaemonInfoWithFallback(ctx, config, data.Cwd)
 	}
 

--- a/daemon/client.go
+++ b/daemon/client.go
@@ -51,6 +51,25 @@ func SendLocalDataToSocket(
 	return nil
 }
 
+// SendSessionProject sends a session-to-project mapping to the daemon (fire-and-forget)
+func SendSessionProject(socketPath string, sessionID, projectPath string) {
+	conn, err := net.DialTimeout("unix", socketPath, 10*time.Millisecond)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	msg := SocketMessage{
+		Type: SocketMessageTypeSessionProject,
+		Payload: SessionProjectRequest{
+			SessionID:   sessionID,
+			ProjectPath: projectPath,
+		},
+	}
+
+	json.NewEncoder(conn).Encode(msg)
+}
+
 // RequestCCInfo requests CC info (cost data and git info) from the daemon
 func RequestCCInfo(socketPath string, timeRange CCInfoTimeRange, workingDir string, timeout time.Duration) (*CCInfoResponse, error) {
 	conn, err := net.DialTimeout("unix", socketPath, timeout)

--- a/model/api_session_project.go
+++ b/model/api_session_project.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type sessionProjectRequest struct {
+	SessionID   string `json:"session_id"`
+	ProjectPath string `json:"project_path"`
+}
+
+type sessionProjectResponse struct{}
+
+// SendSessionProjectUpdate sends a session-to-project path mapping to the server
+func SendSessionProjectUpdate(ctx context.Context, config ShellTimeConfig, sessionID, projectPath string) error {
+	ctx, span := modelTracer.Start(ctx, "session_project.send")
+	defer span.End()
+
+	var resp sessionProjectResponse
+	err := SendHTTPRequestJSON(HTTPRequestOptions[*sessionProjectRequest, sessionProjectResponse]{
+		Context: ctx,
+		Endpoint: Endpoint{
+			APIEndpoint: config.APIEndpoint,
+			Token:       config.Token,
+		},
+		Method:  http.MethodPost,
+		Path:    "/api/v1/cc/session-project",
+		Payload: &sessionProjectRequest{
+			SessionID:   sessionID,
+			ProjectPath: projectPath,
+		},
+		Response: &resp,
+		Timeout:  5 * time.Second,
+	})
+
+	return err
+}

--- a/model/cc_statusline_types.go
+++ b/model/cc_statusline_types.go
@@ -8,6 +8,14 @@ type CCStatuslineInput struct {
 	ContextWindow CCStatuslineContextWindow `json:"context_window"`
 	Cwd           string                    `json:"cwd"`
 	Version       string                    `json:"version"`
+	SessionID     string                    `json:"session_id"`
+	Workspace     *CCStatuslineWorkspace    `json:"workspace"`
+}
+
+// CCStatuslineWorkspace represents workspace information from Claude Code
+type CCStatuslineWorkspace struct {
+	CurrentDir string `json:"current_dir"`
+	ProjectDir string `json:"project_dir"`
 }
 
 // CCStatuslineModel represents model information


### PR DESCRIPTION
## Summary
- Parse `session_id` and `workspace` fields from Claude Code statusline JSON input
- Send session→project path mapping to daemon via unix socket (fire-and-forget, ~1ms)
- Daemon forwards mapping to server via `POST /api/v1/cc/session-project`
- Enables server-side pwd enrichment for OTEL events that report `"/"` instead of the actual project directory

## Changes
- **`model/cc_statusline_types.go`**: Add `SessionID` and `Workspace` fields to `CCStatuslineInput`
- **`daemon/socket.go`**: Add `session_project` message type, struct, and handler case
- **`daemon/client.go`**: Add `SendSessionProject()` fire-and-forget socket function
- **`model/api_session_project.go`** (new): `SendSessionProjectUpdate()` HTTP API call
- **`commands/cc_statusline.go`**: Wire up session-project send before daemon info query

## Related
- Server PR: https://github.com/shelltime/server/pull/291

## Test plan
- [ ] Run `cc statusline` with fixture JSON containing `session_id` and `workspace`, verify daemon receives socket message
- [ ] Verify daemon dispatches HTTP call to server endpoint
- [ ] Verify statusline output is unaffected (no latency impact from fire-and-forget send)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
