### PR TITLE
Restrict quota display to macOS due to Keychain OAuth dependency

### DIFF
--- a/commands/cc_statusline.go
+++ b/commands/cc_statusline.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -164,8 +165,10 @@ func formatStatuslineOutput(modelName string, sessionCost, dailyCost float64, se
 		parts = append(parts, color.Gray.Sprint("📊 -"))
 	}
 
-	// Quota utilization
-	parts = append(parts, formatQuotaPart(fiveHourUtil, sevenDayUtil))
+	// Quota utilization (macOS only - requires Keychain for OAuth token)
+	if runtime.GOOS == "darwin" {
+		parts = append(parts, formatQuotaPart(fiveHourUtil, sevenDayUtil))
+	}
 
 	// AI agent time (magenta) - clickable link to user profile
 	if sessionSeconds > 0 {
@@ -224,8 +227,12 @@ func formatQuotaPart(fiveHourUtil, sevenDayUtil *float64) string {
 }
 
 func outputFallback() {
-	quotaPart := wrapOSC8Link(claudeUsageURL, "🚦 -")
-	fmt.Println(color.Gray.Sprint("🌿 - | 🤖 - | 💰 - | 📊 - | " + quotaPart + " | ⏱️ - | 📈 -%"))
+	if runtime.GOOS == "darwin" {
+		quotaPart := wrapOSC8Link(claudeUsageURL, "🚦 -")
+		fmt.Println(color.Gray.Sprint("🌿 - | 🤖 - | 💰 - | 📊 - | " + quotaPart + " | ⏱️ - | 📈 -%"))
+	} else {
+		fmt.Println(color.Gray.Sprint("🌿 - | 🤖 - | 💰 - | 📊 - | ⏱️ - | 📈 -%"))
+	}
 }
 
 // formatSessionDuration formats seconds into a human-readable duration

--- a/commands/cc_statusline_test.go
+++ b/commands/cc_statusline_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -380,15 +381,23 @@ func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_WithQuota() {
 	sd := 23.0
 	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "main", false, &fh, &sd, "", "", "")
 
-	assert.Contains(s.T(), output, "5h:45%")
-	assert.Contains(s.T(), output, "7d:23%")
-	assert.Contains(s.T(), output, "🚦")
+	if runtime.GOOS == "darwin" {
+		assert.Contains(s.T(), output, "5h:45%")
+		assert.Contains(s.T(), output, "7d:23%")
+		assert.Contains(s.T(), output, "🚦")
+	} else {
+		assert.NotContains(s.T(), output, "🚦")
+	}
 }
 
 func (s *CCStatuslineTestSuite) TestFormatStatuslineOutput_WithoutQuota() {
 	output := formatStatuslineOutput("claude-opus-4", 1.23, 4.56, 3661, 75.0, "main", false, nil, nil, "", "", "")
 
-	assert.Contains(s.T(), output, "🚦 -")
+	if runtime.GOOS == "darwin" {
+		assert.Contains(s.T(), output, "🚦 -")
+	} else {
+		assert.NotContains(s.T(), output, "🚦")
+	}
 }
 
 func (s *CCStatuslineTestSuite) TestGetDaemonInfo_PropagatesRateLimitFields() {


### PR DESCRIPTION
## Summary
This PR restricts the quota utilization display feature to macOS only, as it requires Keychain access for OAuth token management. On non-macOS platforms, the quota section is omitted from the statusline output.

## Key Changes
- Added runtime OS detection using `runtime.GOOS` to conditionally include quota information
- Modified `formatStatuslineOutput()` to only append quota part on macOS (`darwin`)
- Updated `outputFallback()` to exclude the quota indicator (`🚦`) on non-macOS systems
- Updated test cases to verify correct behavior on both macOS and non-macOS platforms:
  - macOS tests assert presence of quota indicators and emoji
  - Non-macOS tests assert absence of quota emoji

## Implementation Details
- The quota utilization feature (showing 5-hour and 7-day usage percentages) is now gated behind a macOS check
- Non-macOS systems will display a simplified statusline without the quota section
- Tests use `runtime.GOOS == "darwin"` to conditionally verify expected output format
- Added explanatory comment noting the Keychain/OAuth dependency for the macOS-only restriction

https://claude.ai/code/session_01WFViMSBVF4NRgg9igRsqb3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
