### PR TITLE
Remove SessionID field from CCStatuslineInput

### DIFF
--- a/model/cc_statusline_types.go
+++ b/model/cc_statusline_types.go
@@ -9,7 +9,6 @@ type CCStatuslineInput struct {
 	ContextWindow CCStatuslineContextWindow `json:"context_window"`
 	Cwd           string                    `json:"cwd"`
 	Version       string                    `json:"version"`
-	SessionID     string                    `json:"session_id"`
 	Workspace     *CCStatuslineWorkspace    `json:"workspace"`
 }
 


### PR DESCRIPTION
## Summary
Removed the `SessionID` field from the `CCStatuslineInput` struct type definition.

## Changes
- Removed `SessionID string` field (with `json:"session_id"` tag) from `CCStatuslineInput` struct in `model/cc_statusline_types.go`

## Details
This change simplifies the `CCStatuslineInput` type by eliminating the session ID field that is no longer needed for statusline context information. The struct now contains only the essential fields: `ContextWindow`, `Cwd`, `Version`, and `Workspace`.

https://claude.ai/code/session_01DzoPaHXNpzZeMDEbdyjYn9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
