### PR TITLE
docs(cc-statusline): update docs for clickable links and new fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,17 @@ Add to your Claude Code settings (`~/.claude/settings.json`):
 The status line will display:
 
 ```
-🤖 Opus | 💰 $0.12 | 📊 $3.45 | 📈 45%
+🌿 main* | 🤖 Opus | 💰 $0.12 | 📊 $3.45 | 🚦 5h:23% 7d:12% | ⏱️ 5m30s | 📈 45%
 ```
 
 | Section | Description |
 |---------|-------------|
+| 🌿 Git Branch | Current branch name (`*` if dirty) |
 | 🤖 Model | Current model name |
-| 💰 Session | Current session cost |
-| 📊 Today | Today's total cost (requires daemon + OTEL) |
+| 💰 Session | Current session cost (clickable link to session detail) |
+| 📊 Daily | Today's total cost (clickable link to coding agent page) |
+| 🚦 Quota | Anthropic API quota utilization (macOS only, clickable link to usage settings) |
+| ⏱️ Time | AI agent session duration (clickable link to user profile) |
 | 📈 Context | Context window usage % |
 
 For full details, see [Claude Code Statusline Guide](docs/CC_STATUSLINE.md).


### PR DESCRIPTION
## Summary
- Update `docs/CC_STATUSLINE.md` and `README.md` to match the current `cc statusline` implementation
- Add clickable links section documenting OSC 8 terminal hyperlinks for Session, Daily, Quota, and Time sections
- Fix JSON input example (`working_directory` → `cwd`, add `session_id`, `hook_event_name`, `version`, `workspace`)
- Update output format table with accurate colors (Daily: Yellow/Gray, Time: Magenta/Gray) and link targets
- Add platform note about Linux omitting the quota section entirely
- Add session-project mapping and daemon request timeout (50ms) to performance section
- Update README example output and sections table with all 7 sections

## Test plan
- [ ] Review updated docs against `commands/cc_statusline.go` for accuracy
- [ ] Verify JSON input fields match `model/cc_statusline_types.go`
- [ ] Confirm all link URL patterns match the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
