### PR TITLE
chore(ci): upgrade Go 1.25 to 1.26

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Cache Go modules
         uses: actions/cache@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - uses: PromptPal/github-action@v1.0.3
         env:
           PROMPTPAL_ENDPOINT: ${{ secrets.PROMPTPAL_ENDPOINT }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ ShellTime CLI is a Go-based command-line tool for tracking DevOps work. It consi
 
 ## Development Commands
 
-**Requires Go 1.25+**
+**Requires Go 1.26+**
 
 ### Building
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/malamtime/cli
 
-go 1.25
+go 1.26
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.5.1


### PR DESCRIPTION
## Summary
- Bump Go version from 1.25 to 1.26 in `go.mod`, CI workflows (`pr-check.yaml`, `release.yaml`), and `CLAUDE.md`
- Go 1.26 brings Green Tea GC (10-40% less GC overhead), ~30% faster cgo calls, and new stdlib packages
- No breaking changes; `go mod tidy` ran cleanly with no dependency changes

## Test plan
- [ ] CI passes with Go 1.26
- [ ] `go vet ./...` passes (pre-existing warning in `cmd/cli/main.go` unrelated)
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
