### PR TITLE
Prevent git lock conflicts in daemon background polling

### DIFF
--- a/daemon/git.go
+++ b/daemon/git.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -16,6 +17,16 @@ type GitInfo struct {
 	IsRepo bool
 }
 
+// gitCmd creates a git command that won't acquire optional locks.
+// This prevents conflicts with user-initiated git operations when the daemon
+// polls git status in the background. Uses GIT_OPTIONAL_LOCKS=0 which is
+// equivalent to passing --no-optional-locks to every git command.
+func gitCmd(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = append(os.Environ(), "GIT_OPTIONAL_LOCKS=0")
+	return cmd
+}
+
 // GetGitInfo returns git branch and dirty status for a directory.
 // It uses the native git CLI which is significantly faster and more memory-efficient
 // than the pure-Go go-git implementation, especially on large repositories.
@@ -28,19 +39,19 @@ func GetGitInfo(workingDir string) GitInfo {
 	defer cancel()
 
 	// Check if this is a git repo
-	if err := exec.CommandContext(ctx, "git", "-C", workingDir, "rev-parse", "--git-dir").Run(); err != nil {
+	if err := gitCmd(ctx, "-C", workingDir, "rev-parse", "--git-dir").Run(); err != nil {
 		return GitInfo{}
 	}
 
 	info := GitInfo{IsRepo: true}
 
 	// Get branch name from HEAD
-	if out, err := exec.CommandContext(ctx, "git", "-C", workingDir, "rev-parse", "--abbrev-ref", "HEAD").Output(); err == nil {
+	if out, err := gitCmd(ctx, "-C", workingDir, "rev-parse", "--abbrev-ref", "HEAD").Output(); err == nil {
 		info.Branch = strings.TrimSpace(string(out))
 	}
 
 	// Check dirty status via porcelain output (empty = clean)
-	if out, err := exec.CommandContext(ctx, "git", "-C", workingDir, "status", "--porcelain").Output(); err == nil {
+	if out, err := gitCmd(ctx, "-C", workingDir, "status", "--porcelain").Output(); err == nil {
 		info.Dirty = len(strings.TrimSpace(string(out))) > 0
 	}
 


### PR DESCRIPTION
## Summary
This change prevents the daemon from acquiring optional git locks when polling repository status in the background, eliminating conflicts with user-initiated git operations.

## Key Changes
- Added `gitCmd()` helper function that wraps `exec.CommandContext` and sets the `GIT_OPTIONAL_LOCKS=0` environment variable
- Replaced all direct `exec.CommandContext` calls in `GetGitInfo()` with the new `gitCmd()` helper
- Updated three git command invocations: `rev-parse --git-dir`, `rev-parse --abbrev-ref HEAD`, and `status --porcelain`

## Implementation Details
The `GIT_OPTIONAL_LOCKS=0` environment variable is equivalent to passing `--no-optional-locks` to every git command. This prevents the daemon from holding locks that could block user-initiated git operations while it performs background status checks. The helper function centralizes this behavior for consistency and maintainability.

https://claude.ai/code/session_01QqiZJAKYLKtTxLZt7tREhu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
