### PR TITLE
Add support for codex.tool_decision event mapping

### DIFF
--- a/daemon/aicode_otel_processor.go
+++ b/daemon/aicode_otel_processor.go
@@ -617,6 +617,8 @@ func mapEventName(name string, source string) string {
 		return model.AICodeEventApiRequest
 	case "codex.api_error":
 		return model.AICodeEventApiError
+	case "codex.tool_decision":
+		return model.AICodeEventToolDecision
 	case "codex.exec_command":
 		return model.AICodeEventExecCommand
 	case "codex.conversation_starts":

--- a/daemon/aicode_otel_processor_test.go
+++ b/daemon/aicode_otel_processor_test.go
@@ -247,6 +247,7 @@ func TestMapEventName_Codex(t *testing.T) {
 		{"codex.tool_result", model.AICodeEventToolResult},
 		{"codex.api_request", model.AICodeEventApiRequest},
 		{"codex.api_error", model.AICodeEventApiError},
+		{"codex.tool_decision", model.AICodeEventToolDecision},
 		{"codex.exec_command", model.AICodeEventExecCommand},
 		{"codex.conversation_starts", model.AICodeEventConversationStarts},
 		{"codex.sse_event", model.AICodeEventSSEEvent},


### PR DESCRIPTION
## Summary
Added support for mapping the `codex.tool_decision` event type to the corresponding `AICodeEventToolDecision` model constant in the OTEL processor.

## Changes
- Added case handler for `"codex.tool_decision"` event in `mapEventName()` function that returns `model.AICodeEventToolDecision`
- Added corresponding test case to verify the event mapping works correctly

## Details
This change enables the OTEL processor to properly recognize and map tool decision events from the Codex system, allowing these events to be tracked and processed alongside other AI code events. The implementation follows the existing pattern used for other event types in the codebase.

https://claude.ai/code/session_01GGSxiNwFb739Q6NXPdhVJ2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
