### PR TITLE
feat(model): enable key features by default

### DIFF
--- a/model/types.go
+++ b/model/types.go
@@ -115,17 +115,25 @@ var DefaultConfig = ShellTimeConfig{
 	FlushCount:  10,
 	// 2 weeks by default
 	GCTime:        14,
-	DataMasking:   nil,
+	DataMasking:   new(true),
 	Endpoints:     nil,
 	EnableMetrics: nil,
-	Encrypted:     nil,
+	Encrypted:     new(true),
 	AI:            DefaultAIConfig,
 	Exclude:       []string{},
-	CCUsage:       nil,
-	CCOtel:        nil, // deprecated
-	AICodeOtel:    nil,
-	CodeTracking:  nil,
-	LogCleanup:    nil,
+	CCUsage: new(CCUsage{
+		Enabled: new(true),
+	}),
+	CCOtel: nil,
+	AICodeOtel: new(AICodeOtel{
+		Enabled:  new(true),
+		GRPCPort: 54027,
+		Debug:    new(false),
+	}),
+	CodeTracking: new(CodeTracking{
+		Enabled: new(true),
+	}),
+	LogCleanup: nil,
 
 	SocketPath: DefaultSocketPath,
 }


### PR DESCRIPTION
## Summary
- Enable data masking and encryption by default for better security out of the box
- Enable CCUsage, AICodeOtel, and code tracking by default so new users get the full feature set
- AICodeOtel defaults to gRPC port 54027 with debug disabled

## Test plan
- [ ] Verify new defaults are applied correctly for fresh installs
- [ ] Verify existing users with `config.local.toml` overrides are not affected
- [ ] Run `go test ./model/...` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
