### PR TITLE
fix(daemon): include debug context in OTEL metrics log

### DIFF
--- a/daemon/aicode_otel_processor.go
+++ b/daemon/aicode_otel_processor.go
@@ -80,7 +80,7 @@ func (p *AICodeOtelProcessor) writeDebugFile(filename string, data interface{}) 
 
 // ProcessMetrics receives OTEL metrics and forwards to backend immediately
 func (p *AICodeOtelProcessor) ProcessMetrics(ctx context.Context, req *collmetricsv1.ExportMetricsServiceRequest) (*collmetricsv1.ExportMetricsServiceResponse, error) {
-	slog.Debug("AICodeOtel: Processing metrics request", "resourceMetricsCount", len(req.GetResourceMetrics()))
+	slog.Debug("AICodeOtel: Processing metrics request", "resourceMetricsCount", slog.Int("len", len(req.GetResourceMetrics())), slog.Bool("debug", p.debug))
 
 	if p.debug {
 		p.writeDebugFile("aicode-otel-debug-metrics.txt", req)


### PR DESCRIPTION
## Summary
- update OTEL metrics processing debug log to include structured length and debug mode context
- keep logging at debug level while improving observability for daemon diagnostics

## Testing
- not run (not requested)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
