### PR TITLE
feat(init): auto-install CC and Codex OTEL configs during init

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -7,7 +7,7 @@ import (
 
 var InitCommand *cli.Command = &cli.Command{
 	Name:  "init",
-	Usage: "Initialize shelltime: authenticate, install hooks, and start daemon",
+	Usage: "Initialize shelltime: authenticate, install hooks, start daemon, and configure AI code integrations",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:     "token",
@@ -35,6 +35,16 @@ func commandInit(c *cli.Context) error {
 	// Step 3: Install daemon service
 	if err := commandDaemonInstall(c); err != nil {
 		return err
+	}
+
+	// Step 4: Install Claude Code OTEL configuration
+	if err := commandCCInstall(c); err != nil {
+		color.Red.Printf("Failed to install Claude Code OTEL config: %v\n", err)
+	}
+
+	// Step 5: Install Codex OTEL configuration
+	if err := commandCodexInstall(c); err != nil {
+		color.Red.Printf("Failed to install Codex OTEL config: %v\n", err)
 	}
 
 	color.Green.Println("ShellTime is fully initialized and ready to use!")


### PR DESCRIPTION
## Summary
- Make `shelltime init` a one-stop setup by auto-installing Claude Code and Codex OTEL configurations after the daemon install step
- Reuses existing `commandCCInstall` and `commandCodexInstall` which are already idempotent
- Failures are non-blocking (logged but don't halt init)

## Test plan
- [x] `go build` compiles successfully
- [x] `go vet ./commands/...` passes
- [x] `go test ./commands/... ./model/...` passes
- [ ] Run `shelltime init` end-to-end and verify CC/Codex OTEL configs are installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
