### PR TITLE
Support additional rate limit categories in Codex usage

### DIFF
--- a/daemon/codex_ratelimit.go
+++ b/daemon/codex_ratelimit.go
@@ -162,9 +162,10 @@ func loadCodexAuth() (*codexAuthData, error) {
 
 // whamUsageResponse maps the response from chatgpt.com/backend-api/wham/usage
 type whamUsageResponse struct {
-	PlanType            string                 `json:"plan_type"`
-	RateLimit           *whamRateLimitCategory `json:"rate_limit"`
-	CodeReviewRateLimit *whamRateLimitCategory `json:"code_review_rate_limit"`
+	PlanType             string                                `json:"plan_type"`
+	RateLimit            *whamRateLimitCategory                `json:"rate_limit"`
+	CodeReviewRateLimit  *whamRateLimitCategory                `json:"code_review_rate_limit"`
+	AdditionalRateLimits map[string]*whamRateLimitCategory     `json:"additional_rate_limits"`
 }
 
 type whamRateLimitCategory struct {
@@ -227,6 +228,18 @@ func fetchCodexUsage(ctx context.Context, auth *codexAuthData) (*CodexRateLimitD
 		}
 		if w := cat.category.SecondaryWindow; w != nil {
 			windows = append(windows, mapWhamWindow(cat.name, "secondary", w))
+		}
+	}
+
+	for name, cat := range usage.AdditionalRateLimits {
+		if cat == nil {
+			continue
+		}
+		if w := cat.PrimaryWindow; w != nil {
+			windows = append(windows, mapWhamWindow(name, "primary", w))
+		}
+		if w := cat.SecondaryWindow; w != nil {
+			windows = append(windows, mapWhamWindow(name, "secondary", w))
 		}
 	}
 


### PR DESCRIPTION
## Summary
Extended the Codex rate limit handling to support additional rate limit categories beyond the primary `rate_limit` and `code_review_rate_limit` fields.

## Key Changes
- Added `AdditionalRateLimits` field to `whamUsageResponse` struct to capture additional rate limit categories from the backend API response
- Updated struct field alignment for consistency
- Extended `fetchCodexUsage()` to iterate through and process additional rate limit categories, mapping both primary and secondary windows for each category

## Implementation Details
The new `AdditionalRateLimits` field is a map that allows the API response to include arbitrary additional rate limit categories. The code processes each category similarly to the existing rate limit categories, extracting primary and secondary windows and converting them to the internal `CodexRateLimitData` format using the existing `mapWhamWindow()` function.

https://claude.ai/code/session_017aLMXajKTAGqTgYimP7UXk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
