### PR TITLE
Add Homebrew tap distribution for ShellTime CLI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,3 +63,4 @@ jobs:
           QUILL_NOTARY_KEY: ${{ secrets.QUILL_NOTARY_KEY }}
           QUILL_NOTARY_KEY_ID: ${{ secrets.QUILL_NOTARY_KEY_ID }}
           QUILL_NOTARY_ISSUER: ${{ secrets.QUILL_NOTARY_ISSUER }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -136,3 +136,34 @@ notarize:
         key_id: "{{.Env.QUILL_NOTARY_KEY_ID}}"
         key: "{{.Env.QUILL_NOTARY_KEY}}"
         wait: true
+brews:
+  - name: shelltime
+    ids:
+      - mt-common
+      - mac
+    repository:
+      owner: shelltime
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://shelltime.xyz"
+    description: "Track and analyze your shell usage - ShellTime CLI"
+    license: "MIT"
+    commit_author:
+      name: shelltime-bot
+      email: bot@shelltime.xyz
+    install: |
+      bin.install "shelltime"
+      bin.install "shelltime-daemon"
+    test: |
+      system "#{bin}/shelltime", "--version"
+    caveats: |
+      To get started with ShellTime, run:
+        shelltime init
+
+      Or set up manually:
+        shelltime auth
+        shelltime hooks install
+        shelltime daemon install
+
+      For more info, visit https://shelltime.xyz


### PR DESCRIPTION
## Summary
This PR adds Homebrew tap distribution support to the ShellTime CLI release pipeline, enabling users to install ShellTime via Homebrew on macOS.

## Key Changes
- **GoReleaser Configuration**: Added Homebrew formula configuration to `.goreleaser.yaml` that:
  - Targets the `shelltime/homebrew-tap` repository
  - Includes both `mt-common` and `mac` build artifacts
  - Installs both `shelltime` and `shelltime-daemon` binaries
  - Provides setup instructions via caveats (init, auth, hooks, daemon installation)
  - Includes version verification test

- **GitHub Actions**: Updated `.github/workflows/release.yaml` to pass the `HOMEBREW_TAP_GITHUB_TOKEN` secret to the release job, enabling automated formula updates to the Homebrew tap repository

## Implementation Details
- The Homebrew formula will be published to the `Formula` directory in the `shelltime/homebrew-tap` repository
- Automated commits are made by `shelltime-bot` account
- Post-installation caveats guide users through the initial setup process
- The configuration uses environment variable substitution for the GitHub token to maintain security

https://claude.ai/code/session_01TwCfzkqy4jkzx6UaZjHdp6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shelltime/cli/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
