### PR TITLE
fix(daemon): propagate error when daemon binary not found on reinstall

### DIFF
--- a/commands/daemon.install.go
+++ b/commands/daemon.install.go
@@ -42,10 +42,10 @@ func commandDaemonInstall(c *cli.Context) error {
 	// Resolve daemon binary (Homebrew/PATH preferred, curl-installer fallback)
 	daemonBinPath, err := model.ResolveDaemonBinaryPath()
 	if err != nil {
-		color.Yellow.Println("⚠️ shelltime-daemon not found.")
+		color.Red.Println("❌ shelltime-daemon binary not found.")
 		color.Yellow.Println("Install via Homebrew:  brew install shelltime/tap/shelltime")
 		color.Yellow.Println("Or via curl installer: curl -sSL https://shelltime.xyz/i | bash")
-		return nil
+		return fmt.Errorf("shelltime-daemon binary not found: %w", err)
 	}
 	color.Green.Printf("✅ Found daemon binary at: %s\n", daemonBinPath)
 


### PR DESCRIPTION
## Summary

- `shelltime daemon reinstall` on Linux printed a green "✅ Daemon service has been successfully reinstalled!" even when the install step couldn't locate the `shelltime-daemon` binary — the service was uninstalled and never replaced, but the CLI claimed success.
- Root cause: `commandDaemonInstall` swallowed the `model.ResolveDaemonBinaryPath()` error with `return nil` after printing a yellow hint, so the reinstall wrapper saw `nil` and printed the success line.
- Fix: return a wrapped error so reinstall (and direct `daemon install`) actually exit non-zero. Also switched the "not found" line from yellow ⚠️ to red ❌ so it reads as the failure it is.

## Test plan

- [x] `go build -o /tmp/shelltime ./cmd/cli/main.go` — compiles
- [x] `go test -run TestResolveDaemonBinaryPath ./model/` — passes
- [ ] On a Linux box without `shelltime-daemon` on PATH or under `~/.shelltime/bin/`: `shelltime daemon reinstall` should print the red "not found" line plus install hints, omit the green success line, and exit non-zero
- [ ] With a real `shelltime-daemon` available on PATH: `shelltime daemon reinstall` still prints the green success line and exits 0

https://claude.ai/code/session_01LBLq3b7dqsgfcSAEmnWDcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBLq3b7dqsgfcSAEmnWDcY)_