### PR TITLE
fix(daemon): preserve curl-installer daemon as .bak instead of deleting

### DIFF
--- a/commands/daemon.install.go
+++ b/commands/daemon.install.go
@@ -61,16 +61,20 @@ func commandDaemonInstall(c *cli.Context) error {
 		color.Green.Printf("✅ Found daemon binary at: %s\n", daemonBinPath)
 	}
 
-	// If we picked a system-managed binary but a stale curl-installer copy
-	// still lives under ~/.shelltime/bin, remove it so future resolution
-	// stays unambiguous.
+	// If we picked a system-managed binary but a curl-installer copy still
+	// lives under ~/.shelltime/bin, rename it to shelltime-daemon.bak rather
+	// than delete it. Future resolution stays unambiguous AND the .bak
+	// recovery branch above can restore it on the next `daemon install` —
+	// no GitHub re-download when the user later clears the system binary.
 	curlDaemonPath := model.GetCurlInstallerDaemonPath()
 	if daemonBinPath != curlDaemonPath {
 		if info, statErr := os.Stat(curlDaemonPath); statErr == nil && !info.IsDir() {
-			if rmErr := os.Remove(curlDaemonPath); rmErr == nil {
-				color.Yellow.Printf("🧹 Removed stale curl-installer daemon at %s\n", curlDaemonPath)
+			preservedPath := curlDaemonPath + ".bak"
+			_ = os.Remove(preservedPath)
+			if rnErr := os.Rename(curlDaemonPath, preservedPath); rnErr == nil {
+				color.Yellow.Printf("📦 Preserved curl-installer daemon as %s (auto-restores on next `daemon install`).\n", preservedPath)
 			} else {
-				color.Yellow.Printf("⚠️ Could not remove stale daemon at %s: %v\n", curlDaemonPath, rmErr)
+				color.Yellow.Printf("⚠️ Could not preserve curl-installer daemon at %s: %v\n", curlDaemonPath, rnErr)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- When `commandDaemonInstall` resolves to a system-managed binary (Homebrew on macOS, or a stale `/usr/local/bin/shelltime-daemon` on Linux), the cleanup branch previously **deleted** `~/.shelltime/bin/shelltime-daemon`. Combined with `install.bash` running `shelltime daemon reinstall` on upgrades, this removed the binary `install.bash` had just extracted — and the next `daemon install` re-downloaded it from GitHub releases.
- Rename the curl-installer copy to `shelltime-daemon.bak` instead of removing it. The existing `.bak` recovery branch at the top of `commandDaemonInstall` (lines 32-40) restores it on the next run, so once the user clears the stale system binary the daemon binary returns with no network fetch.
- No changes to `install.bash`. No changes to `model/path.go` resolution preference.

## Repro / before vs after

Setup (Linux, simulating the stale-system-binary case):
```bash
rm -rf ~/.shelltime
touch /usr/local/bin/shelltime-daemon
# install.bash placed a fresh daemon here:
go build -o ~/.shelltime/bin/shelltime-daemon ./cmd/daemon/main.go
shelltime daemon reinstall
```

- **Before:** `~/.shelltime/bin/shelltime-daemon` is gone. Next `shelltime daemon install` hits GitHub releases to re-download.
- **After:** `~/.shelltime/bin/shelltime-daemon.bak` exists. After the user clears `/usr/local/bin/shelltime-daemon` and re-runs `shelltime daemon install`, the existing `.bak` recovery branch promotes it back to `shelltime-daemon` — no network fetch.

## Test plan

- [ ] `go build ./...` succeeds
- [ ] `go test ./model/...` green (`path_test.go` resolution cases unchanged)
- [ ] Linux: stale `/usr/local/bin/shelltime-daemon` + fresh `~/.shelltime/bin/shelltime-daemon` → after `daemon install`, `.bak` exists; after clearing the stale system binary and re-running, `.bak` is consumed and `shelltime-daemon` is restored
- [ ] macOS Homebrew: with a leftover curl-installer copy in `~/.shelltime/bin`, `daemon install` renames it to `.bak` (logged) and service starts against the Homebrew binary
- [ ] Repeated reinstalls don't pile up `.bak` files (pre-rename `os.Remove(preservedPath)` clears any stale `.bak`)

## Out of scope

- The platform-unguarded `/usr/local/bin` entry in `daemonHomebrewSearchPaths` (resolution preference unchanged).
- The service still being registered against the stale `/usr/local/bin` binary for one reinstall cycle — user still needs to manually clear that. This fix only ensures their good binary survives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQicN9K37VxNmoDkMm63Up)_