### PR TITLE
feat(model): report storage engine in tracking metadata

### DIFF
--- a/daemon/handlers.track_test.go
+++ b/daemon/handlers.track_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,6 +24,8 @@ type fakeCommandStore struct {
 
 	cursorSetCalls int
 	pruneCalls     int
+
+	engine string
 }
 
 func (f *fakeCommandStore) SavePre(ctx context.Context, cmd model.Command, rt time.Time) error {
@@ -70,6 +73,13 @@ func (f *fakeCommandStore) SetCursor(ctx context.Context, cursor time.Time) erro
 func (f *fakeCommandStore) Prune(ctx context.Context, cursor time.Time) error {
 	f.pruneCalls++
 	return nil
+}
+
+func (f *fakeCommandStore) Engine() string {
+	if f.engine == "" {
+		return model.StorageEngineFile
+	}
+	return f.engine
 }
 
 func (f *fakeCommandStore) Close() error { return nil }
@@ -184,12 +194,14 @@ func (s *TrackHandlerTestSuite) TestTrackPostNotEnoughToFlush() {
 }
 
 func (s *TrackHandlerTestSuite) TestTrackPostFlushSyncsAndPrunes() {
+	var sentPayload model.PostTrackArgs
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&sentPayload)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
-	store := &fakeCommandStore{noCursorExist: true}
+	store := &fakeCommandStore{noCursorExist: true, engine: model.StorageEngineBolt}
 	commandStore = store
 	stConfig = fakeConfigService{cfg: model.ShellTimeConfig{Token: "t", APIEndpoint: server.URL, FlushCount: 1}}
 
@@ -204,6 +216,9 @@ func (s *TrackHandlerTestSuite) TestTrackPostFlushSyncsAndPrunes() {
 	assert.Len(s.T(), store.post, 1)
 	assert.Equal(s.T(), 1, store.cursorSetCalls)
 	assert.Equal(s.T(), 1, store.pruneCalls)
+	// the payload must report the engine that buffered the commands
+	assert.Equal(s.T(), model.StorageEngineBolt, sentPayload.Meta.CliEngine)
+	assert.Equal(s.T(), 1, sentPayload.Meta.Source, "daemon path must mark source as daemon")
 }
 
 func (s *TrackHandlerTestSuite) TestTrackPostFallsBackToFileStore() {

--- a/model/api.go
+++ b/model/api.go
@@ -32,6 +32,10 @@ type TrackingMetaData struct {
 	Terminal    string `json:"terminal,omitempty"`
 	Multiplexer string `json:"multiplexer,omitempty"`
 
+	// CliEngine is the storage engine that buffered these commands:
+	// StorageEngineFile or StorageEngineBolt.
+	CliEngine string `json:"cliEngine,omitempty"`
+
 	// 0: cli, 1: daemon
 	Source int `json:"source"`
 }

--- a/model/store.go
+++ b/model/store.go
@@ -42,6 +42,11 @@ type CommandStore interface {
 	// before the cursor), keeping unfinished pre commands.
 	Prune(ctx context.Context, cursor time.Time) error
 
+	// Engine reports which storage engine backs this store (StorageEngineFile
+	// or StorageEngineBolt). It is attached to sync metadata so the server
+	// knows how the commands were buffered.
+	Engine() string
+
 	// Close releases any resources held by the store (no-op for fileStore).
 	Close() error
 }

--- a/model/store_bolt.go
+++ b/model/store_bolt.go
@@ -241,6 +241,8 @@ func (s *boltStore) Prune(ctx context.Context, cursor time.Time) error {
 	})
 }
 
+func (s *boltStore) Engine() string { return StorageEngineBolt }
+
 func (s *boltStore) Close() error {
 	if s.db == nil {
 		return nil

--- a/model/store_file.go
+++ b/model/store_file.go
@@ -155,4 +155,6 @@ func (s *fileStore) Prune(ctx context.Context, cursor time.Time) error {
 	return os.WriteFile(GetCursorFilePath(), []byte(fmt.Sprintf("%d", cursor.UnixNano())), 0644)
 }
 
+func (s *fileStore) Engine() string { return StorageEngineFile }
+
 func (s *fileStore) Close() error { return nil }

--- a/model/tracking_build.go
+++ b/model/tracking_build.go
@@ -56,6 +56,7 @@ func BuildTrackingData(ctx context.Context, store CommandStore, config ShellTime
 	meta := TrackingMetaData{
 		OS:        sysInfo.Os,
 		OSVersion: sysInfo.Version,
+		CliEngine: store.Engine(),
 	}
 
 	trackingData := make([]TrackingData, 0)

--- a/model/tracking_build_test.go
+++ b/model/tracking_build_test.go
@@ -32,6 +32,28 @@ func TestBuildTrackingData(t *testing.T) {
 	require.Equal(t, 42, res.Data[0].PPID)
 	require.Equal(t, "h", res.Meta.Hostname)
 	require.Equal(t, "bash", res.Meta.Shell)
+	require.Equal(t, StorageEngineBolt, res.Meta.CliEngine)
+}
+
+func TestBuildTrackingDataFileEngine(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	InitFolder("") // reset globals to the default .shelltime under the temp HOME
+
+	store := NewFileStore()
+	defer store.Close()
+
+	ctx := context.Background()
+	start := time.Now()
+	cmd := Command{Shell: "zsh", SessionID: 3, Command: "ls -la", Username: "u", Hostname: "h", Time: start}
+	require.NoError(t, store.SavePre(ctx, cmd, start))
+	post := cmd
+	post.Time = start.Add(time.Second)
+	require.NoError(t, store.SavePost(ctx, post, 0, post.Time))
+
+	res, err := BuildTrackingData(ctx, store, ShellTimeConfig{})
+	require.NoError(t, err)
+	require.Len(t, res.Data, 1)
+	require.Equal(t, StorageEngineFile, res.Meta.CliEngine)
 }
 
 func TestBuildTrackingDataExcludes(t *testing.T) {


### PR DESCRIPTION
## Why

Follow-up to #284: the server (shelltime/server#451) now records which local storage engine buffered each synced command, so web/iOS can display it and suggest switching to bolt.

## What

- `CommandStore` gains `Engine() string` (`StorageEngineFile` / `StorageEngineBolt`), implemented by both stores
- `TrackingMetaData` gains `cliEngine` (omitempty), populated in `BuildTrackingData` from the store the payload was actually read from

Setting it at payload-assembly time means all three send paths report the truth without further changes:
- daemon bolt path (`daemon/handlers.track.go`)
- CLI txt-file fallback (`commands/track.go`)
- legacy CLI→daemon socket sync (meta travels inside `PostTrackArgs`; `sendTrackArgsToServer` doesn't touch it)

A config that says `bolt` while the daemon is down still correctly reports `file`, because the engine comes from the store, not the config.

## Verification

- `go vet ./...` clean; `go test ./model/ ./commands/ ./daemon/` pass
- New assertions: `BuildTrackingData` meta reports `bolt` for the bolt store and `file` for the file store; the daemon flush test now decodes the HTTP body and asserts `meta.cliEngine == "bolt"` and `source == 1`
- `TestGitInfoTestSuite` fails in this sandbox environment, same as on `main` (documented in #284)

Companion PRs: shelltime/server#451, shelltime/web, shelltime/ios.

https://claude.ai/code/session_015ZzRC212TzpPdHwwcxKohA

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZzRC212TzpPdHwwcxKohA)_