### PR TITLE
fix(ci): migrate .goreleaser.yaml off deprecated archives/brews APIs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,10 +52,10 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.uptraceDsn={{.Env.UPTRACE_DSN}}
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     id: mt-common
     allow_different_binary_count: true
-    builds:
+    ids:
       - mt-common
       - mt-daemon-linux
     # this name template makes the OS and Arch compatible with the results of uname.
@@ -69,11 +69,11 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
-  - format: zip
+        formats: [zip]
+  - formats: [zip]
     id: mac
     allow_different_binary_count: true
-    builds:
+    ids:
       - mt-mac
       - mt-daemon-mac
     name_template: >-
@@ -135,27 +135,25 @@ notarize:
         key_id: "{{.Env.QUILL_NOTARY_KEY_ID}}"
         key: "{{.Env.QUILL_NOTARY_KEY}}"
         wait: true
-brews:
+# Homebrew Casks are macOS-only; Linux users install via the curl script.
+homebrew_casks:
   - name: shelltime
     ids:
-      - mt-common
       - mac
+    binaries:
+      - shelltime
+      - shelltime-daemon
     repository:
       owner: shelltime
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: "https://shelltime.xyz"
     description: "Track and analyze your shell usage - ShellTime CLI"
     license: "MIT"
     commit_author:
       name: shelltime-bot
       email: bot@shelltime.xyz
-    install: |
-      bin.install "shelltime"
-      bin.install "shelltime-daemon"
-    test: |
-      system "#{bin}/shelltime", "--version"
     caveats: |
       Get started with a single command:
         shelltime init


### PR DESCRIPTION
## Why
The release workflow runs `goreleaser release --clean` with `version: "~> v2"`. `goreleaser check` (v2.16.0) reports four deprecated properties that will eventually become hard errors:

```
DEPRECATED: archives.format
DEPRECATED: archives.format_overrides.format
DEPRECATED: archives.builds
DEPRECATED: brews
```

## Changes
- **`archives` (both entries):** `format:` → `formats: [...]`, `builds:` → `ids:`, and `format_overrides[].format` → `formats: [...]`.
- **`brews` → `homebrew_casks`:** Homebrew Casks are **macOS-only**, so the tap becomes macOS-only.
  - `binaries: [shelltime, shelltime-daemon]` replaces the Ruby `install` block.
  - `test` stanza dropped (casks have none).
  - `ids: [mac]` only (drops the Linux/Windows `mt-common` archive).
  - `directory: Formula` → `Casks`.

Linux users continue installing via `curl -sSL https://shelltime.xyz/i | bash`. The GitHub-release archives (incl. Linux/Windows) are unchanged.

## Verification
- `goreleaser check` → passes, no deprecations.
- `goreleaser release --snapshot --clean --skip=publish` → builds all 4 binaries, both archive formats, and generates `dist/homebrew/Casks/shelltime.rb` with `binary "shelltime"` + `binary "shelltime-daemon"` and caveats, scoped to macOS intel/arm.

## Companion PR
Requires shelltime/homebrew-tap#NEW (adds `tap_migrations.json`, removes the old formula) so existing users auto-migrate to the cask. Land/release this CLI change first or together to avoid a window where the formula is gone but the cask isn't published yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)