### PR TITLE
fix(hooks): detach fish hook from the tty

### DIFF
--- a/model/hooks/fish.fish
+++ b/model/hooks/fish.fish
@@ -4,7 +4,9 @@
 if not command -v shelltime > /dev/null
     echo "Warning: shelltime CLI not found. Please install it to enable time tracking."
 else
-    shelltime gc
+    # Detached from the tty: this runs while fish is still probing the terminal
+    # (OSC 11 / CPR / DA1) at startup, and must not sit on the input queue.
+    shelltime gc < /dev/null
 end
 
 # Create a timestamp for the session when the shell starts
@@ -19,7 +21,7 @@ function fish_preexec --on-event fish_preexec
         return
     end
 
-    shelltime track -s=fish -id=$SESSION_ID -cmd="$argv" -p=pre --ppid=$FISH_PPID > /dev/null
+    shelltime track -s=fish -id=$SESSION_ID -cmd="$argv" -p=pre --ppid=$FISH_PPID < /dev/null > /dev/null 2>&1
 end
 
 # Define the postexec function
@@ -29,5 +31,5 @@ function fish_postexec --on-event fish_postexec
         return
     end
     # This event is triggered before each prompt, which is after each command
-    shelltime track -s=fish -id=$SESSION_ID -cmd="$argv" -p=post -r=$LAST_RESULT --ppid=$FISH_PPID > /dev/null
+    shelltime track -s=fish -id=$SESSION_ID -cmd="$argv" -p=post -r=$LAST_RESULT --ppid=$FISH_PPID < /dev/null > /dev/null 2>&1
 end


### PR DESCRIPTION
## Problem

Escape text like `^[]11;rgb:1010/1010/1010^[\^[[32;1R^[[?62;22;52c` intermittently
appears on the fish command line after Ctrl-C'ing a long-running foreground job.

Those bytes are not corruption — they are the terminal's *replies* to queries fish
sends. fish 4.1+ probes the terminal (the `query-term` feature, on by default) with:

| query | meaning | reply seen |
|---|---|---|
| `ESC]11;?ESC\` | background colour | `ESC]11;rgb:1010/1010/1010ESC\` |
| `ESC[6n` | cursor position (CPR) | `ESC[32;1R` |
| `ESC[0c` | device attributes (DA1) | `ESC[?62;22;52c` |

fish emits these at startup and on prompt redraw. The terminal answers by writing into
the tty input queue. A hook child that holds that queue can leave the replies
unconsumed, after which they are read back as ordinary keystrokes and rendered as
literal text at the prompt.

## Change

`model/hooks/fish.fish` was the least protected of the three hooks:

- both `shelltime track` calls used `> /dev/null` — **stdout only**, while
  `hooks/bash.bash` and `hooks/zsh.zsh` both use `&> /dev/null`
- none of the three call sites detached stdin, so every hook child inherited the tty
- `shelltime gc` runs during config load, i.e. inside fish's *startup* query window

All three now use `< /dev/null` so the hook can never sit on terminal input, and the
two `track` calls fold stderr away for parity with bash/zsh.

Kept in the foreground deliberately: backgrounding with `&` makes fish emit job-status
notifications, which is noisier than the problem being fixed.

## Notes

- `ensureHookFile()` (`model/shell.go:24`) returns early when the hook file already
  exists, so existing installs keep their old `~/.shelltime/hooks/fish.fish` until it is
  updated by hand or removed and reinstalled.
- This hardens a plausible contributor; the root-cause bisect (bare fish vs. hooks vs.
  the interrupted process tree) is still outstanding, and fish's own documented escape
  hatch remains `set -Ua fish_features no-query-term`.

## Testing

- `go build ./...`, `go test ./model/...` pass
- `fish --no-execute model/hooks/fish.fish` passes
- `go test ./commands/...` has 10 failures, all pre-existing at `main` (daemon
  unix-socket tests plus one requiring the `open` binary) — verified by re-running at HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)